### PR TITLE
Add Laravel 13 support and PHP 8.5 to CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.2, 8.3, 8.4 ]
+        php: [ 8.2, 8.3, 8.4, 8.5 ]
         stability: [ prefer-stable ]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "php": ">=8.2",
         "ext-json": "*",
         "aws/aws-sdk-php": "^3.2",
-        "illuminate/cache": "^8 || ^9 || ^10 || ^11 || ^12",
-        "illuminate/queue": "^8 || ^9 || ^10 || ^11 || ^12"
+        "illuminate/cache": "^8 || ^9 || ^10 || ^11 || ^12 || ^13",
+        "illuminate/queue": "^8 || ^9 || ^10 || ^11 || ^12 || ^13"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Extend `illuminate/cache` and `illuminate/queue` version constraints to include `^13`
- Add PHP 8.5 to the GitHub Actions CI test matrix

## Test plan
- [x] Verify CI passes for all PHP versions (8.2, 8.3, 8.4, 8.5)
- [x] Confirm package installs correctly with Laravel 13 dependencies